### PR TITLE
Remove sequenceNumber from SNAPSHOT

### DIFF
--- a/Donlon.xml
+++ b/Donlon.xml
@@ -9700,7 +9700,6 @@
 						</gml:TimePeriod>
 					</gml:validTime>
 					<aixm:interpretation>SNAPSHOT</aixm:interpretation>
-					<aixm:sequenceNumber>1</aixm:sequenceNumber>
 					<aixm:featureLifetime>
 						<gml:TimePeriod gml:id="ID_150">
 							<gml:beginPosition>2009-01-01T00:00:00Z</gml:beginPosition>


### PR DESCRIPTION
AIXM Temporality 1.0, page 9:

> Note that for a SNAPSHOT, the correctionNumber and the sequenceNumber properties shall not be populated.

http://www.aixm.aero/gallery/content/public/AIXM51/AIXM%20Temporality%201.0.pdf#page=9
